### PR TITLE
Add noMutate flag, which addresses #12 and adds the ability to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ myObj.myMethod({ msg: "Failure!" }, null).then(null, function(err) {
 });
 ```
 
+Wrap without mutating the original:
+```javascript
+var promisify = require("promisify-node");
+
+var myObj = {
+  myMethod: function(a, b, cb) {
+    cb(a, b);
+  }
+};
+
+// Store the original method to check later
+var originalMethod = myObj.myMethod;
+
+// Now store the result, since the 'true' value means it won't mutate 'myObj'.
+var promisifiedObj = promisify(myObj, undefined, true);
+
+// Intentionally cause a failure by passing an object and inspect the message.
+promisifiedObj.myMethod({ msg: "Failure!" }, null).then(null, function(err) {
+  console.log(err.msg);
+});
+
+// The original method is still intact
+assert(myObj.myMethod === originalMethod);
+assert(promisifiedObj.myMethod !== myObj.myMethod);
+```
+
 ### Tests ###
 
 Run the tests after installing dependencies with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Wrap Node-callback functions to return Promises.",
   "main": "index.js",
   "dependencies": {
-    "nodegit-promise": "~4.0.0"
+    "nodegit-promise": "~4.0.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/test/examples/fn-export.js
+++ b/test/examples/fn-export.js
@@ -1,0 +1,2 @@
+module.exports = function(d, cb) { setTimeout(cb, d); };
+module.exports.x = function(d, cb) { setTimeout(cb, d); };

--- a/test/examples/proto-export.js
+++ b/test/examples/proto-export.js
@@ -1,0 +1,3 @@
+function A(d) { this.d = d; }
+A.prototype.a = function(cb) { setTimeout(cb, this.d); };
+module.exports = A;

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,13 @@
 var promisify = require("../");
-var assert = require("assert");
+var assert = require("assert"),
+    fsOriginal = require('fs');
 
 describe("Promisify", function() {
+  function isPromisified(fn, ctx) {
+    var result = fn && fn.apply(ctx, Array.prototype.slice.call(arguments, 2));
+    return result && (typeof result.then === 'function');
+  }
+
   it("can convert a basic async function", function() {
     function test(cb) {
       cb(null, true);
@@ -29,6 +35,41 @@ describe("Promisify", function() {
       fs = promisify("fs");
 
       return fs.readFile(__dirname + "/../LICENSE");
+    });
+
+    it("doesn't mutate objects for other consumers", function() {
+      var fsp = promisify("fs");
+      var fs2 = require("fs");
+
+      assert(fsOriginal.readFile !== fsp.readFile, "pre-required mutated");
+      assert(fsOriginal.readFile === fs2.readFile, "post-required mutated");
+      assert(fsp.readFile !== fs2.readFile, "post-required mutated");
+    });
+
+    it("doesn't mutate functions for other consumers", function() {
+      var fn = require(__dirname + "/examples/fn-export.js");
+      var fnx = fn.x;
+      var fnp = promisify(__dirname + "/examples/fn-export.js");
+      var fn2 = require(__dirname + "/examples/fn-export.js");
+
+      assert(fn.x !== fnp, "pre-required mutated");
+      assert(fn2.x !== fnp, "post-required mutated");
+      assert(fn.x === fnx, "function property mutated");
+      assert(fnp.x !== fn, "function property not replaced");
+    });
+
+    it("doesn't mutate prototypes for other consumers", function() {
+      var A = require(__dirname + "/examples/proto-export.js");
+      var a = new A(5);
+      var Ap = promisify(__dirname + "/examples/proto-export.js");
+      var ap = new Ap(5);
+      var A2 = require(__dirname + "/examples/proto-export.js");
+      var a2 = new A2(5);
+
+      assert(isPromisified(ap.a, ap), "prototype method not promisified");
+      assert(a.a !== ap.a, "pre-required mutated");
+      assert(a2.a !== ap.a, "post-required mutated");
+      assert(a2.a === a.a, "post-required mutated");
     });
   });
 
@@ -135,6 +176,46 @@ describe("Promisify", function() {
       assert(typeof a(5).then === "function", "function not wrapped");
       assert(a.a(5) !== undefined, "function property not wrapped");
       assert(typeof a.a(5).then === "function", "function property not wrapped");
+    });
+  });
+
+
+  describe("no mutate", function() {
+    it("can promisify an object without mutating it", function() {
+      var a = {
+        a: function(cb) { cb(); }
+      };
+
+      var b = promisify(a, undefined, true);
+
+      assert(isPromisified(b.a, b), "method not promisified");
+      assert(a.a !== b.a, "object mutated");
+    });
+
+    it("can promisify a function's properties without mutating it", function() {
+      var a = function(cb){ cb(null, 1); };
+      a.a = function(cb) { cb(); };
+
+      var b = promisify(a, undefined, true);
+
+      assert(isPromisified(b), "method not promisified");
+      assert(isPromisified(b.a, b), "method property not promisified");
+      assert(a.a !== b, "method property mutated");
+      assert(a.a !== b.a, "method property mutated");
+    });
+
+    it("can promisify a constructor without mutating it", function() {
+      var A = function(){ };
+      A.a = function(cb) { cb(); };
+      A.prototype.a = function(cb) { cb(null, 2); };
+
+      var B = promisify(A, undefined, true);
+      var b = new B();
+
+      assert(isPromisified(B.a, B), "method property not promisified");
+      assert(isPromisified(b.a, b), "prototype method not promisified");
+      assert(A.a !== B.a, "method property mutated");
+      assert(A.prototype.a !== b.a, "prototype mutated");
     });
   });
 });

--- a/utils/cloneFunction.js
+++ b/utils/cloneFunction.js
@@ -1,0 +1,17 @@
+/**
+ * Clones a function, including copying any properties of the function to the clone.
+ *
+ * @param {Function} func - The function to clone.
+ */
+module.exports = function cloneFn(func) {
+    var temp;
+    // Check for the memoized value on the function in-case we get called to wrap the same function
+    // (or already wrapped function) again.
+    return func.__cloneFn || (temp = function() {
+      return func.apply(this, arguments);
+    }) &&
+    // Assign __proto__ as a quick way to copy function properties.
+    (temp.__proto__ = func) &&
+    // Lastly, set a cache var on the original and clone, and return the result.
+    (func.__cloneFn = temp.__cloneFn = temp);
+};


### PR DESCRIPTION
…disable object mutation through the public API.

This ended up needing some fairly significant changes, but I think being able to prevent mutation (particularly for the case of require calls, as in #12) is a very helpful feature that does warrant it.