### PR TITLE
updated arg regex

### DIFF
--- a/utils/args.js
+++ b/utils/args.js
@@ -6,8 +6,8 @@
  */
 module.exports = function(func) {
   // First match everything inside the function argument parens.
-  var args = func.toString().match(/function\s.*?\(([^)]*)\)/)[1];
- 
+  var args = func.toString().match(/^[function\s]?.*?\(([^)]*)\)/)[1];
+
   // Split the arguments string into an array comma delimited.
   return args.split(", ").map(function(arg) {
     // Ensure no inline comments are parsed and trim the whitespace.


### PR DESCRIPTION
A fix for issue: #18 
I have updated the regex to support the following additional function definitions:

test(cb){cb();} //example: class Test {  constructor(){} test(cb){cb();} }
(cb)=>{cb()}

I was going to add test cases to prove that it accepts the new function declarations, but I didn't want to break your build in older versions of node since you have .10 and .12 in your `.travis.yml`
