### PR TITLE
Fix regexp for anonymous functions

### DIFF
--- a/utils/args.js
+++ b/utils/args.js
@@ -6,7 +6,7 @@
  */
 module.exports = function(func) {
   // First match everything inside the function argument parens.
-  var args = func.toString().match(/function\s.*?\(([^)]*)\)/)[1];
+  var args = func.toString().match(/function(?:\s.*)?\(([^)]*)\)/)[1];
  
   // Split the arguments string into an array comma delimited.
   return args.split(", ").map(function(arg) {


### PR DESCRIPTION
The arguments-matching regexp in _utils/arg.js_ fails for anonymous functions (`function(args) { ... }`) because it expects a space after `function`.

Add a non-capturing group to make the space and function name optional.

This was spotted while trying to build nodegit from source.