### PR TITLE
Less restictive fn-args regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - 5
+  - 6
+  - 8
+  - 9
+  - 10
 
 branches:
   only:
@@ -12,5 +12,3 @@ branches:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: 0.11

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function processExports(exports, test, cached, parentKeyName, noMutate) {
     }
 
     // Find methods on the prototype, if there are any.
-    if (Object.keys(exports.prototype).length) {
+    if (exports.prototype && Object.keys(exports.prototype).length) {
       // Attach the augmented prototype.
       wrapped.prototype = processExports(exports.prototype, test, cached, name, noMutate);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -98,6 +98,14 @@ describe("Promisify", function() {
       return obj.a();
     });
 
+    it("can infer callback-accepting arrow functions", function() {
+      var obj = promisify({
+        a: (cb) => { later(cb); }
+      });
+
+      return obj.a();
+    });
+
     it("can infer callback-accepting functions by argument list", function() {
       var obj = promisify({
         a: function(callback) { later(callback); }

--- a/utils/args.js
+++ b/utils/args.js
@@ -6,8 +6,8 @@
  */
 module.exports = function(func) {
   // First match everything inside the function argument parens.
-  var args = func.toString().match(/function\s.*?\(([^)]*)\)/)[1];
- 
+  var args = func.toString().match(/([^(])*\(([^)]*)\)/)[2];
+
   // Split the arguments string into an array comma delimited.
   return args.split(", ").map(function(arg) {
     // Ensure no inline comments are parsed and trim the whitespace.


### PR DESCRIPTION
This changes the regex to match arguments from the first parens, instead
of explicitly matching function keyword and then parens. This allows for
arrow functions and fixes issues with Node 10.