### PR TITLE
This dynamic require is a no-go in webpack environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,25 +143,15 @@ function processExports(exports, test, cached, parentKeyName, noMutate) {
 /**
  * Public API for Promisify.  Will resolve modules names using `require`.
  *
- * @param {*} name - Can be a module name, object, or function.
+ * @param {*} name - Can be an object or function.
  * @param {Function} test - Optional function to identify async methods.
  * @param {Boolean} noMutate - Optional set to true to avoid mutating the target.
  * @returns {*} exports - The resolved value from require or passed in value.
  */
-module.exports = function(name, test, noMutate) {
-  var exports = name;
-
-  // If the name argument is a String, will need to resovle using the built in
-  // Node require function.
-  if (typeof name === "string") {
-    exports = require(name);
-    // Unless explicitly overridden, don't mutate when requiring modules.
-    noMutate = !(noMutate === false);
-  }
-
+module.exports = function(toPromisify, test, noMutate) {
   // Iterate over all properties and find asynchronous functions to convert to
   // promises.
-  return processExports(exports, test, [], undefined, noMutate);
+  return processExports(toPromisify, test, [], undefined, noMutate);
 };
 
 // Export callbacks to the module.

--- a/test/index.js
+++ b/test/index.js
@@ -24,55 +24,6 @@ describe("Promisify", function() {
     assert(Array.isArray(promisify.callbacks));
   });
 
-  describe("node modules", function() {
-    it("can be consumed", function() {
-      var fs = promisify("fs");
-      return fs.readFile(__dirname + "/../LICENSE");
-    });
-
-    it("can promisify the same object twice without breaking", function() {
-      var fs = promisify("fs");
-      fs = promisify("fs");
-
-      return fs.readFile(__dirname + "/../LICENSE");
-    });
-
-    it("doesn't mutate objects for other consumers", function() {
-      var fsp = promisify("fs");
-      var fs2 = require("fs");
-
-      assert(fsOriginal.readFile !== fsp.readFile, "pre-required mutated");
-      assert(fsOriginal.readFile === fs2.readFile, "post-required mutated");
-      assert(fsp.readFile !== fs2.readFile, "post-required mutated");
-    });
-
-    it("doesn't mutate functions for other consumers", function() {
-      var fn = require(__dirname + "/examples/fn-export.js");
-      var fnx = fn.x;
-      var fnp = promisify(__dirname + "/examples/fn-export.js");
-      var fn2 = require(__dirname + "/examples/fn-export.js");
-
-      assert(fn.x !== fnp, "pre-required mutated");
-      assert(fn2.x !== fnp, "post-required mutated");
-      assert(fn.x === fnx, "function property mutated");
-      assert(fnp.x !== fn, "function property not replaced");
-    });
-
-    it("doesn't mutate prototypes for other consumers", function() {
-      var A = require(__dirname + "/examples/proto-export.js");
-      var a = new A(5);
-      var Ap = promisify(__dirname + "/examples/proto-export.js");
-      var ap = new Ap(5);
-      var A2 = require(__dirname + "/examples/proto-export.js");
-      var a2 = new A2(5);
-
-      assert(isPromisified(ap.a, ap), "prototype method not promisified");
-      assert(a.a !== ap.a, "pre-required mutated");
-      assert(a2.a !== ap.a, "post-required mutated");
-      assert(a2.a === a.a, "post-required mutated");
-    });
-  });
-
   describe("asynchronous method inference", function() {
     var later = function(cb) {
       setTimeout(cb(null), 0);


### PR DESCRIPTION
While this is convenient, it makes the library difficult to use with webpack and other bundlers.